### PR TITLE
fix: Validate domain length per TLD

### DIFF
--- a/src/mcp_domain_availability/main.py
+++ b/src/mcp_domain_availability/main.py
@@ -41,6 +41,43 @@ NEW_TLDS = [
 
 ALL_TLDS = list(set(POPULAR_TLDS + COUNTRY_TLDS + NEW_TLDS))
 
+TLD_MIN_LENGTH = {
+    "com": 3, "net": 3, "org": 3, "info": 3, "biz": 3,
+    "io": 3, "ai": 3, "co": 3, "me": 3,
+    "de": 3, "fr": 3, "it": 3, "es": 3, "nl": 3,
+    "ch": 3, "at": 3, "be": 3, "dk": 3, "se": 3,
+    "no": 3, "fi": 3, "pl": 3, "cz": 3, "pt": 3,
+    "gr": 3, "tr": 3, "ru": 3, "uk": 3, "au": 3,
+    "ca": 3, "us": 3, "jp": 3, "kr": 3, "cn": 3,
+    "in": 3, "br": 3, "mx": 3, "ar": 3, "cl": 3,
+    "pe": 3, "za": 3, "eg": 3, "ma": 3, "ng": 3,
+    "ke": 3,
+    
+    "app": 3, "dev": 3, "xyz": 3, "tech": 3,
+    "online": 3, "site": 3, "website": 3, "store": 3,
+    "shop": 3, "cloud": 3, "digital": 3, "blog": 3,
+    "news": 3
+}
+
+def get_min_length_for_tld(tld: str) -> int:
+    """Obtiene la longitud mínima requerida para un TLD"""
+    return TLD_MIN_LENGTH.get(tld, 3)
+
+def is_valid_domain_name(base_name: str, tld: str) -> bool:
+    """Valida si un nombre de dominio cumple con las reglas del TLD"""
+    min_length = get_min_length_for_tld(tld)
+    if len(base_name) < min_length:
+        return False
+    if not re.match(r'^[a-z0-9]([a-z0-9-]*[a-z0-9])?$', base_name):
+        return False
+    if base_name.startswith('-') or base_name.endswith('-'):
+        return False
+    if '--' in base_name:
+        return False
+    if len(base_name) > 63:
+        return False
+    return True
+
 def clean_domain_name(domain: str) -> str:
     domain = domain.lower().strip()
     if domain.startswith('http://') or domain.startswith('https://'):
@@ -136,6 +173,15 @@ async def check_domain_socket(domain: str) -> bool:
 
 async def check_domain_availability(domain: str) -> Dict:
     start_time = time.time()
+    base_name, tld = extract_domain_parts(domain)
+    if not is_valid_domain_name(base_name, tld):
+        return {
+            'domain': domain,
+            'available': False,
+            'error': f'Invalid domain: "{base_name}" does not meet requirements for .{tld} (min length: {get_min_length_for_tld(tld)})',
+            'valid': False,
+            'check_time': "0s"
+        }
     
     dns_available = await check_domain_dns(domain)
     whois_available = await check_domain_whois(domain)
@@ -150,6 +196,7 @@ async def check_domain_availability(domain: str) -> Dict:
         'available': is_available,
         'dns_available': dns_available,
         'whois_available': whois_available,
+        'valid': True,
         'check_time': f"{check_time}s"
     }
 
@@ -158,8 +205,11 @@ async def check_multiple_domains(base_name: str, tlds: List[str]) -> List[Dict]:
     
     async def check_with_semaphore(tld: str):
         async with semaphore:
-            domain = f"{base_name}.{tld}"
-            return await check_domain_availability(domain)
+            if is_valid_domain_name(base_name, tld):
+                domain = f"{base_name}.{tld}"
+                return await check_domain_availability(domain)
+            else:
+                return None
     
     tasks = [check_with_semaphore(tld) for tld in tlds]
     results = await asyncio.gather(*tasks, return_exceptions=True)
@@ -168,7 +218,7 @@ async def check_multiple_domains(base_name: str, tlds: List[str]) -> List[Dict]:
     for result in results:
         if isinstance(result, dict):
             valid_results.append(result)
-        else:
+        elif result is not None and not isinstance(result, Exception):
             print(f"Error checking domain: {result}")
     
     return valid_results
@@ -180,9 +230,26 @@ async def run_domain_checks(domain_part: str) -> Dict:
         "requested_domain": None,
         "available_domains": [],
         "unavailable_domains": [],
+        "invalid_domains": [],
         "total_checked": 0,
         "check_summary": {}
     }
+    
+    invalid_for_tlds = []
+    for tld in ALL_TLDS:
+        if not is_valid_domain_name(base_name, tld):
+            min_length = get_min_length_for_tld(tld)
+            invalid_for_tlds.append({
+                'tld': tld,
+                'reason': f'Minimum length: {min_length} chars'
+            })
+    
+    if invalid_for_tlds:
+        results["invalid_domains"] = {
+            'base_name': base_name,
+            'length': len(base_name),
+            'invalid_for': invalid_for_tlds[:10]
+        }
     
     if existing_tld:
         exact_result = await check_domain_availability(f"{base_name}.{existing_tld}")
@@ -190,12 +257,13 @@ async def run_domain_checks(domain_part: str) -> Dict:
         
         other_tlds = [tld for tld in ALL_TLDS if tld != existing_tld]
         all_results = await check_multiple_domains(base_name, other_tlds)
-        all_results.append(exact_result)
+        if exact_result.get('valid', True):
+            all_results.append(exact_result)
     else:
         all_results = await check_multiple_domains(base_name, ALL_TLDS)
     
     for result in all_results:
-        if result['available']:
+        if result.get('available'):
             results["available_domains"].append(result)
         else:
             results["unavailable_domains"].append(result)
@@ -210,6 +278,7 @@ async def run_domain_checks(domain_part: str) -> Dict:
     results["check_summary"] = {
         "total_available": len(results["available_domains"]),
         "total_unavailable": len(results["unavailable_domains"]),
+        "total_invalid": len(invalid_for_tlds),
         "popular_available": len(popular_available),
         "country_available": len([r for r in results["available_domains"] 
                                 if any(r['domain'].endswith(f'.{tld}') for tld in COUNTRY_TLDS)]),


### PR DESCRIPTION
## Prevent invalid two-letter domains from being listed as available

### Summary

This pull request addresses issue #2 by implementing robust domain name validation. It prevents second-level domains (SLDs) that do not meet minimum length requirements or other syntax rules for their respective Top-Level Domains (TLDs) from being processed and incorrectly reported as available.

### Motivation

Previously, the application would perform DNS/WHOIS checks on domains even if their structure was invalid according to TLD-specific rules, such as minimum length. This led to scenarios where invalid two-letter domains (e.g., `ab.ch`, `ab.at`) were incorrectly shown as available because they passed basic syntax but failed TLD-specific constraints. This PR resolves this by validating domains *before* network checks, ensuring only genuinely valid domains are processed and reported.

Closes #2

### Changes Made

1.  **Added TLD Minimum Length Data:** Introduced a `TLD_MIN_LENGTH` dictionary to store the minimum allowed length for SLDs under various TLDs. This allows for TLD-specific validation rules.
2.  **Implemented Domain Validation Function:** Created a new function `is_valid_domain_name` that performs comprehensive validation of the SLD. This includes checking against the minimum length specified in `TLD_MIN_LENGTH`, verifying the character set, and applying basic hyphen rules.
3.  **Integrated Validation into Checking Logic:** The `is_valid_domain_name` function is now called within `check_domain_availability` and `check_multiple_domains` to filter out invalid domains early in the process.
4.  **Enhanced Output:** Modified the `run_domain_checks` function to include a list of `invalid_domains` in its output. This list provides clear feedback to the user about which domains were deemed invalid and, where applicable, the reason (e.g., "Minimum length: 3 chars").

### Technical Implementation

The core change involves adding a validation step early in the domain checking pipeline. By checking validity based on TLD rules before initiating network requests, we avoid unnecessary DNS/WHOIS lookups for domains that are inherently invalid.

Regarding the minimum length validation specifically, comprehensive, readily available data on the precise minimum SLD length requirements for *all* 50+ TLDs is difficult to find. To ensure robust validation and prevent potential registration issues, the current implementation conservatively sets the minimum SLD length to 3 characters for *all* TLDs without exception. While some TLDs *may* permit 2-character SLDs, this blanket rule prioritizes preventing invalid registrations based on common requirements. The `TLD_MIN_LENGTH` dictionary is included to provide a configurable way to handle varying TLD requirements *if* more specific data becomes available in the future. Future research and data acquisition may allow for more granular, TLD-specific minimum length rules to be implemented.

### Important Notes

The output structure of the `run_domain_checks` function has been modified to include the `invalid_domains` key. Any code consuming the output of this function should be updated to handle this new key if necessary.

### Impact

This enhancement significantly improves the accuracy and reliability of the domain availability checks. Users will no longer receive misleading "available" results for domains that are syntactically impossible to register. The explicit listing of invalid domains with reasons also provides better feedback, helping users understand why certain domain requests were not processed.

Closes #2