### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,3 +376,8 @@ This project is licensed under the Mozilla Public License 2.0 - see the [LICENSE
 - [Claude Desktop](https://claude.ai/download)
 - [uv Package Manager](https://docs.astral.sh/uv/)
 - [MCP Series](https://github.com/mcp-series)
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/imprvhub-mcp-domain-availability).
+


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/imprvhub-mcp-domain-availability)