### PR TITLE
Pin mcp SDK to <2.0.0 to restore mcp.server.fastmcp import

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,34 @@ If you see connection errors in Claude Desktop:
 2. **Check Python version**:
    - Ensure Python 3.10+ is available: `python3 --version`
 
+#### "ModuleNotFoundError: No module named 'mcp.server.fastmcp'"
+The MCP Python SDK 2.0.0 removed the bundled `mcp.server.fastmcp` module. This server targets the 1.x API, so its dependencies are pinned to `mcp<2.0.0`. If you hit this error, you are running a cached install that resolved the SDK before that pin:
+
+1. **Refresh the cached install**:
+   - Run `uvx --refresh --from git+https://github.com/imprvhub/mcp-domain-availability mcp-domain-availability`
+   - If uv is reusing a persistent tool install, run `uv tool upgrade mcp-domain-availability`
+
+2. **Or pin the SDK from your client config**:
+   - Add `"--with", "mcp<2.0.0"` to the `args` array in `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "mcp-domain-availability": {
+      "command": "uvx",
+      "args": [
+        "--python=3.10",
+        "--from",
+        "git+https://github.com/imprvhub/mcp-domain-availability",
+        "--with",
+        "mcp<2.0.0",
+        "mcp-domain-availability"
+      ]
+    }
+  }
+}
+```
+
 ### DNS resolution issues
 If domain checks are failing:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "MCP server for checking domain availability across multiple TLDs"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "mcp[cli]>=1.3.0",
+    "mcp[cli]>=1.3.0,<2.0.0",
     "requests>=2.32.3",
     "aiohttp>=3.11.13",
     "asyncio",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.10",
     install_requires=[
-        "mcp[cli]>=1.3.0",
+        "mcp[cli]>=1.3.0,<2.0.0",
         "requests>=2.32.3", 
         "aiohttp>=3.11.13",
         "dnspython>=2.4.0",


### PR DESCRIPTION
The MCP Python SDK released 2.0.0, which removed the bundled mcp.server.fastmcp module (the ergonomic server class moved to mcp.server.mcpserver and was renamed FastMCP -> MCPServer).

Because the dependency was declared as "mcp[cli]>=1.3.0" with no upper bound and the repository ships no lock file, every fresh resolution (uv sync, uvx --from git+...) now installs 2.0.0 and the server fails at import time with:

    ModuleNotFoundError: No module named 'mcp.server.fastmcp'

Add the "<2.0.0" upper bound in pyproject.toml and setup.py, matching the upstream SDK's own guidance to keep a <2 bound until migrating. Also document the error under Troubleshooting for users on a cached install, covering both `uvx --refresh` and the client-side "--with", "mcp<2.0.0" workaround.

This is containment, not a migration; porting to the 2.x MCPServer API remains a separate change.

Fixes imprvhub/mcp-domain-availability#9